### PR TITLE
Build and push image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: bionic
 env:
   global:
-    - LOCAL_IMAGE="graph-notebook:local"
+    - LOCAL_IMAGE="graph-notebook-docker:local"
     - DEV_IMAGE="purpleteam/graph-notebook-docker-dev:$TRAVIS_COMMIT"
     - RELEASE_IMAGE="adevinta/graph-notebook-docker"
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ deploy:
     skip_cleanup: true
     script: ./script/push_docker.sh $LOCAL_IMAGE $DEV_IMAGE
     on:
+      all_branches: true
       tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,4 @@ deploy:
     skip_cleanup: true
     script: ./script/push_docker.sh $LOCAL_IMAGE $DEV_IMAGE
     on:
-      all_branches: true
       tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+dist: bionic
+env:
+  global:
+    - LOCAL_IMAGE="graph-notebook:local"
+    - DEV_IMAGE="purpleteam/graph-notebook-dev-ephemeral:$TRAVIS_COMMIT"
+    - RELEASE_IMAGE="adevinta/graph-notebook-docker"
+services:
+  - docker
+script:
+  - docker build -t $LOCAL_IMAGE .
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: ./script/push_docker.sh $LOCAL_IMAGE $RELEASE_IMAGE
+    on:
+      tags: true
+  - provider: script
+    skip_cleanup: true
+    script: ./script/push_docker.sh $LOCAL_IMAGE $DEV_IMAGE
+    on:
+      all_branches: true
+      tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: bionic
 env:
   global:
     - LOCAL_IMAGE="graph-notebook:local"
-    - DEV_IMAGE="purpleteam/graph-notebook-dev-ephemeral:$TRAVIS_COMMIT"
+    - DEV_IMAGE="purpleteam/graph-notebook-docker-dev:$TRAVIS_COMMIT"
     - RELEASE_IMAGE="adevinta/graph-notebook-docker"
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install 'notebook==5.7.10' && \
     pip install 'rdflib==5.0.0'
 
 # Install the graph-notebook package.
-RUN pip install 'graph-notebook==2.1.2'
+RUN pip install 'graph-notebook==3.0.2'
 
 # Install and enable the visualization widget.
 RUN jupyter nbextension install --py --sys-prefix graph_notebook.widgets && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN git clone --depth 1 --branch amazon-neptune-tools-1.2 https://github.com/aws
 
 FROM python:3.6.12-slim
 
-COPY requirements.txt .
 # Install dependencies
+COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 # Install and enable the visualization widget.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.9-slim as builder
+FROM python:3.9-slim-buster as builder
 RUN apt update && apt install -y git
 RUN git clone --depth 1 --branch amazon-neptune-tools-1.2 https://github.com/awslabs/amazon-neptune-tools /amazon-neptune-tools
 
-FROM python:3.9-slim
+FROM python:3.9-slim-buster
 
 # Install the neptune_python_utils dependencies.
 RUN pip install gremlinpython requests backoff

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.6.12-slim as builder
 RUN apt update && apt install -y git
+
+# Clone Neptune tools repo.
 RUN git clone --depth 1 --branch amazon-neptune-tools-1.2 https://github.com/awslabs/amazon-neptune-tools /amazon-neptune-tools
 
 FROM python:3.6.12-slim
-
 # Install dependencies
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,12 @@
-FROM python:3.9-slim-buster as builder
+FROM python:3.6.12-slim as builder
 RUN apt update && apt install -y git
 RUN git clone --depth 1 --branch amazon-neptune-tools-1.2 https://github.com/awslabs/amazon-neptune-tools /amazon-neptune-tools
 
-FROM python:3.9-slim-buster
+FROM python:3.6.12-slim
 
-# Install the neptune_python_utils dependencies.
-RUN pip install gremlinpython requests backoff
-
-# Pin specific versions of Jupyter and Tornado dependency.
-RUN pip install 'notebook==5.7.10' && \
-    pip install 'tornado==4.5.3' && \
-    pip install 'rdflib==5.0.0'
-
-# Install the graph-notebook package.
-RUN pip install 'graph-notebook==3.0.2'
+COPY requirements.txt .
+# Install dependencies
+RUN pip install -r requirements.txt
 
 # Install and enable the visualization widget.
 RUN jupyter nbextension install --py --sys-prefix graph_notebook.widgets && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN pip install gremlinpython requests backoff
 
 # Pin specific versions of Jupyter and Tornado dependency.
 RUN pip install 'notebook==5.7.10' && \
-    pip install 'tornado==4.5.3'
+    pip install 'tornado==4.5.3' && \
+    pip install 'rdflib==5.0.0'
 
 # Install the graph-notebook package.
 RUN pip install 'graph-notebook==2.1.2'

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM python:3.6.12-slim
 # Install dependencies
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+RUN rm requirements.txt
 
 # Install and enable the visualization widget.
 RUN jupyter nbextension install --py --sys-prefix graph_notebook.widgets && \
@@ -36,7 +37,9 @@ WORKDIR /notebooks
 USER jupyter
 
 # Copy the Amazon neptune-python-tools.
-COPY --from=builder /amazon-neptune-tools/neptune-python-utils /home/jupyter
+COPY --from=builder \
+    /amazon-neptune-tools/neptune-python-utils/neptune_python_utils \
+    /home/jupyter/neptune_python_utils
 
 # Copy the neptune helper.
 COPY neptune_helper.py /home/jupyter

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ g.V().limit(10).valueMap().toList()
 [aws/graph-notebook]: https://github.com/aws/graph-notebook
 [aws/neptune-python-utils]: https://github.com/awslabs/amazon-neptune-tools/tree/master/neptune-python-utils
 
+## Versioning
+
+We use the [semantic-versioning](semantic versioning) for tagging the code of a
+belonging to a release. Each release in git has its corresponding tag in this [dockerhub repository].
+
+[dockerhub repository]: https://hub.docker.com/r/adevinta/graph-notebook-docker
+
 ## Contributing
 
 **This project is in an early stage, we are not accepting external
@@ -50,3 +57,4 @@ To contribute, please read the contribution guidelines in [CONTRIBUTING.md].
 
 
 [CONTRIBUTING.md]: CONTRIBUTING.md
+[semantic-versioning]: https://semver.org/spec/v2.0.0.html

--- a/README.md
+++ b/README.md
@@ -47,10 +47,8 @@ g.V().limit(10).valueMap().toList()
 
 ## Versioning
 
-We use the [semantic-versioning](semantic versioning) for tagging the code of a
+We use the [semantic-versioning] for tagging the code of a
 belonging to a release. Each release in git has its corresponding tag in this [dockerhub repository].
-
-[dockerhub repository]: https://hub.docker.com/r/adevinta/graph-notebook-docker
 
 ## Contributing
 
@@ -62,3 +60,4 @@ To contribute, please read the contribution guidelines in [CONTRIBUTING.md].
 
 [CONTRIBUTING.md]: CONTRIBUTING.md
 [semantic-versioning]: https://semver.org/spec/v2.0.0.html
+[dockerhub repository]: https://hub.docker.com/r/adevinta/graph-notebook-docker

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ IAM credentials.
 
 ```bash
 docker run --rm -ti -p 8888:8888 \
-    -e NEPTUNE_ENDPOINT="neptune.endpoint.example.com" \
+    -e NEPTUNE_HOST="neptune.endpoint.example.com" \
     -e NEPTUNE_PORT=8182 \
     -e AWS_ACCESS_KEY_ID  -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
     -e AWS_REGION="eu-west-1" \
@@ -26,7 +26,7 @@ for instance:
 ```bash
 docker run --rm -ti -p 8888:8888 \
     -v $PWD:/notebooks \
-    -e NEPTUNE_ENDPOINT="neptune.endpoint.example.com" \
+    -e NEPTUNE_HOST="neptune.endpoint.example.com" \
     -e NEPTUNE_PORT=8182 \
     -e AWS_ACCESS_KEY_ID  -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
     -e AWS_REGION="eu-west-1" \

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ IAM credentials.
 
 ## Using neptune-python-utils
 
-1. Run the docker image passing in the env vars with your "AWS variables" and the Neptune endpoint:
+1. Run the docker image passing in the env vars with your "AWS variables", the Neptune endpoint host and port:
 ```bash
 docker run --rm -ti -p 8888:8888 \
     -e NEPTUNE_ENDPOINT="neptune.endpoint.example.com" \
+    -e NEPTUNE_PORT=8182 \
     -e AWS_ACCESS_KEY_ID  -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
     -e AWS_REGION="eu-west-1" \
     graph-notebook:1.0.0
@@ -24,6 +25,7 @@ for instance:
 docker run --rm -ti -p 8888:8888 \
     -v $PWD:/notebooks \
     -e NEPTUNE_ENDPOINT="neptune.endpoint.example.com" \
+    -e NEPTUNE_PORT=8182 \
     -e AWS_ACCESS_KEY_ID  -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
     -e AWS_REGION="eu-west-1" \
     graph-notebook:1.0.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ IAM credentials.
 
 ## Using neptune-python-utils
 
-1. Run the docker image passing in the env vars with your "AWS variables", the Neptune endpoint host and port:
+1. Run the docker image passing the environment variables corresponding to your
+   "AWS variables", the Neptune's host and the Neptune's port:
+
 ```bash
 docker run --rm -ti -p 8888:8888 \
     -e NEPTUNE_ENDPOINT="neptune.endpoint.example.com" \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ IAM credentials.
 ## Using neptune-python-utils
 
 1. Run the docker image passing the environment variables corresponding to your
-   "AWS variables", the Neptune's host and the Neptune's port:
+   "AWS variables", Neptune's host and Neptune's port:
 
 ```bash
 docker run --rm -ti -p 8888:8888 \
@@ -47,8 +47,8 @@ g.V().limit(10).valueMap().toList()
 
 ## Versioning
 
-We use [semantic-versioning] for tagging the code of a release.
-Each release in git has its corresponding tag in this [dockerhub repository].
+We use [semantic-versioning] for releases. Each release in git has its
+corresponding tag in this [dockerhub repository].
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ g.V().limit(10).valueMap().toList()
 
 ## Versioning
 
-We use the [semantic-versioning] for tagging the code of a
-belonging to a release. Each release in git has its corresponding tag in this [dockerhub repository].
+We use [semantic-versioning] for tagging the code of a release.
+Each release in git has its corresponding tag in this [dockerhub repository].
 
 ## Contributing
 

--- a/neptune_helper.py
+++ b/neptune_helper.py
@@ -36,8 +36,8 @@ def iam_connect():
     if session_token is None:
         raise EnvironmentVariableNotSetError('AWS_SESSION_TOKEN')
 
-    NEPTUNE_HOST = getenv('NEPTUNE_HOST', None)
-    if NEPTUNE_HOST is None:
+    neptune_host = getenv('NEPTUNE_HOST', None)
+    if neptune_host is None:
         raise EnvironmentVariableNotSetError('NEPTUNE_HOST')
 
     neptune_port = getenv('NEPTUNE_PORT', None)
@@ -50,7 +50,7 @@ def iam_connect():
                       aws_session_token=session_token,
                       region_name=region)
     credentials = session.get_credentials()
-    endpoints = Endpoints(NEPTUNE_HOST=NEPTUNE_HOST,
+    endpoints = Endpoints(neptune_endpoint=neptune_host,
                           neptune_port=neptune_port,
                           region_name=region,
                           credentials=credentials)

--- a/neptune_helper.py
+++ b/neptune_helper.py
@@ -10,7 +10,7 @@ def iam_connect():
     Creates a connection using IAM authorization.
     The function needs the following env vars to be defined:
     AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_REGION
-    and NEPTUNE_ENDPOINT.
+    and NEPTUNE_HOST.
 
     Returns:
     A 'g' object that can be used to run queries against
@@ -36,9 +36,9 @@ def iam_connect():
     if session_token is None:
         raise EnvironmentVariableNotSetError('AWS_SESSION_TOKEN')
 
-    neptune_endpoint = getenv('NEPTUNE_ENDPOINT', None)
-    if neptune_endpoint is None:
-        raise EnvironmentVariableNotSetError('NEPTUNE_ENDPOINT')
+    NEPTUNE_HOST = getenv('NEPTUNE_HOST', None)
+    if NEPTUNE_HOST is None:
+        raise EnvironmentVariableNotSetError('NEPTUNE_HOST')
 
     neptune_port = getenv('NEPTUNE_PORT', None)
     if neptune_port is None:
@@ -50,7 +50,7 @@ def iam_connect():
                       aws_session_token=session_token,
                       region_name=region)
     credentials = session.get_credentials()
-    endpoints = Endpoints(neptune_endpoint=neptune_endpoint,
+    endpoints = Endpoints(NEPTUNE_HOST=NEPTUNE_HOST,
                           neptune_port=neptune_port,
                           region_name=region,
                           credentials=credentials)

--- a/neptune_helper.py
+++ b/neptune_helper.py
@@ -40,9 +40,7 @@ def iam_connect():
     if neptune_host is None:
         raise EnvironmentVariableNotSetError('NEPTUNE_HOST')
 
-    neptune_port = getenv('NEPTUNE_PORT', None)
-    if neptune_port is None:
-        neptune_port = 8182
+    neptune_port = getenv('NEPTUNE_PORT', '8182')
 
     GremlinUtils.init_statics(globals())
     session = Session(aws_access_key_id=access_key,
@@ -51,7 +49,7 @@ def iam_connect():
                       region_name=region)
     credentials = session.get_credentials()
     endpoints = Endpoints(neptune_endpoint=neptune_host,
-                          neptune_port=neptune_port,
+                          neptune_port=int(neptune_port),
                           region_name=region,
                           credentials=credentials)
     gremlin_utils = GremlinUtils(endpoints)

--- a/neptune_helper.py
+++ b/neptune_helper.py
@@ -40,6 +40,10 @@ def iam_connect():
     if neptune_endpoint is None:
         raise EnvironmentVariableNotSetError('NEPTUNE_ENDPOINT')
 
+    neptune_port = getenv('NEPTUNE_PORT', None)
+    if neptune_port is None:
+        neptune_port = 8182
+
     GremlinUtils.init_statics(globals())
     session = Session(aws_access_key_id=access_key,
                       aws_secret_access_key=secret_key,
@@ -47,7 +51,7 @@ def iam_connect():
                       region_name=region)
     credentials = session.get_credentials()
     endpoints = Endpoints(neptune_endpoint=neptune_endpoint,
-                          neptune_port=8182,
+                          neptune_port=neptune_port,
                           region_name=region,
                           credentials=credentials)
     gremlin_utils = GremlinUtils(endpoints)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ rdflib==5.0.0
 gremlinpython==3.4.12
 
 # neptune_python_utils dependencies.
-requests==2.26.0
+backoff==1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
-# graph-notebook
+# graph-notebook dependencies.
 graph-notebook==3.0.2
 notebook==5.7.10
 tornado==4.5.3
 rdflib==5.0.0
-# amazon-neptune-tools
 gremlinpython==3.4.12
+
+# neptune_python_utils dependencies.
 requests==2.26.0
-backoff==1.11.1
-cchardet==2.1.7
-aiodns==3.0.0
-idna-ssl==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+notebook==5.7.10
+tornado==4.5.3
+rdflib==5.0.0
+graph-notebook==3.0.2
+gremlinpython==3.4.12
+requests==2.26.0
+backoff==1.11.1
+cchardet==2.1.7
+aiodns==3.0.0
+idna-ssl==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+# graph-notebook
+graph-notebook==3.0.2
 notebook==5.7.10
 tornado==4.5.3
 rdflib==5.0.0
-graph-notebook==3.0.2
+# amazon-neptune-tools
 gremlinpython==3.4.12
 requests==2.26.0
 backoff==1.11.1

--- a/script/push_docker.sh
+++ b/script/push_docker.sh
@@ -9,7 +9,7 @@
 # must belong to a valid user with permission to push to the docker image
 # registry the script will push the image to.
 
-set -ev
+set -eu
 if [ -z "$1" ]
   then
     echo "no local image tag specified"

--- a/script/push_docker.sh
+++ b/script/push_docker.sh
@@ -4,10 +4,11 @@
 
 # This script tags and pushes a locally existent docker image to a specified new
 # tag. It receives two parameters, the first one specifies the tag of the local
-# image, and the second one the tag to push the image to. It expects the env
-# variables: DOCKER_USERNAME and DOCKER_PASSWORD to be set to the credentials of
-# a valid user with permission to push to the docker imaghe registry used in the
-# tag the script will push the image to.
+# image and the second one the tag to push the image to. It expects the env
+# variables: DOCKER_USERNAME and DOCKER_PASSWORD to be set. Those credentials
+# must belong to a valid user with permission to push to the docker image
+# registry the script will push the image to.
+
 set -ev
 if [ -z "$1" ]
   then

--- a/script/push_docker.sh
+++ b/script/push_docker.sh
@@ -10,20 +10,17 @@
 # registry the script will push the image to.
 
 set -eu
-if [ -z "$1" ]
-  then
-    echo "no local image tag specified"
-fi
 
-if [ -z "$2" ]
-  then
-    echo "no image tag to push to specified"
+if [ $# -ne 2 ]; then
+    echo "usage: $0 <local_image> <push_image>" >&2
+    exit 2
 fi
 
 LOCAL_TAG=$1
 PUSH_TAG=$2
-docker tag $LOCAL_TAG $PUSH_TAG
-echo ${DOCKER_PASSWORD} | docker login -u $DOCKER_USERNAME --password-stdin
+
+docker tag "${LOCAL_TAG}" "${PUSH_TAG}"
+echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 echo "pushing image to repository ${PUSH_TAG}"
-docker push $PUSH_TAG
+docker push "${PUSH_TAG}"
 docker logout

--- a/script/push_docker.sh
+++ b/script/push_docker.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Copyright 2021 Adevinta
+
+# This script tags and pushes a locally existent docker image to a specified new
+# tag. It receives two parameters, the first one specifies the tag of the local
+# image, and the second one the tag to push the image to. It expects the env
+# variables: DOCKER_USERNAME and DOCKER_PASSWORD to be set to the credentials of
+# a valid user with permission to push to the docker imaghe registry used in the
+# tag the script will push the image to.
+set -ev
+if [ -z "$1" ]
+  then
+    echo "no local image tag specified"
+fi
+
+if [ -z "$2" ]
+  then
+    echo "no image tag to push to specified"
+fi
+
+LOCAL_TAG=$1
+PUSH_TAG=$2
+docker tag $LOCAL_TAG $PUSH_TAG
+echo ${DOCKER_PASSWORD} | docker login -u $DOCKER_USERNAME --password-stdin
+echo "pushing image to repository ${PUSH_TAG}"
+docker push $PUSH_TAG
+docker logout

--- a/script/push_docker.sh
+++ b/script/push_docker.sh
@@ -12,7 +12,7 @@
 set -eu
 
 if [ $# -ne 2 ]; then
-    echo "usage: $0 <local_image> <push_image>" >&2
+    echo "usage: $0 <local_tag> <push_tag>" >&2
     exit 2
 fi
 


### PR DESCRIPTION
This PR setups the CI in the repository.

Specifically, it setups Travis so when a new tag in this github repo is created, it builds and pushes a docker image to the repository `adevinta/graph-notebook-docker:[tag]` of the public docker hub.

Also when a new commit is made, it builds and pushes the docker image to the public docker hub repository: 
`purpleteam/graph-notebook-docker-dev:[commit]`. The images in this repository are intended to be used only for internal testing. 

Apart from that, the PR sets the Python version used in the docker base images to one "officially" supported by the `graph-notebook` dependency and pins the direct dependencies of `neptune-python-utils`.