### PR TITLE
ci: fix error in release tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   global:
     - LOCAL_IMAGE="graph-notebook-docker:local"
     - DEV_IMAGE="purpleteam/graph-notebook-docker-dev:$TRAVIS_COMMIT"
-    - RELEASE_IMAGE="adevinta/graph-notebook-docker"
+    - RELEASE_IMAGE="adevinta/graph-notebook-docker:$TRAVIS_TAG"
 services:
   - docker
 script:


### PR DESCRIPTION
This PR just fixes a bug in the travis.yaml file that was causing incorrect generation of the docker image's tag for releases.